### PR TITLE
Mapper 등록 방식 통일 및 쿼리 최적화(N+1 문제 해결, 동적 SQL)

### DIFF
--- a/src/main/java/com/example/shoppingmall/HomeController.java
+++ b/src/main/java/com/example/shoppingmall/HomeController.java
@@ -24,31 +24,36 @@ public class HomeController {
 
     @GetMapping("/")
     public String home(@RequestParam(required = false) String message,
-                       HttpServletRequest request, // HttpServletRequest 추가
-                       Model model) {// 수정: message 파라미터 추가
+                       HttpServletRequest request,
+                       Model model) {
 
         log.info("==================== HomeController 호출 ====================");
         log.info("요청 IP: {}", request.getRemoteAddr());
         log.info("User-Agent: {}", request.getHeader("User-Agent"));
 
-        List<ItemDto> bestSellers = itemService.getBestSellers();
-        List<ItemDto> newReleases = itemService.getNewItems();
+//        List<ItemDto> bestSellers = itemService.getBestSellers();
+//        List<ItemDto> newReleases = itemService.getNewItems();
 
-        bestSellers.forEach(item -> {
-            ItemDto summary = itemService.getItemWithReviewSummary(item.getItemId());
-            if (summary != null) {
-                item.setAverageRating(summary.getAverageRating());
-                item.setReviewCount(summary.getReviewCount());
-            }
-        });
+        // [수정] N+1 문제가 해결된 서비스 메소드를 직접 호출
+        // (JOIN을 통해 아이템 목록과 리뷰 요약 정보를 한 번의 쿼리로 가져옴)
+        List<ItemDto> bestSellers = itemService.getBestSellersWithReviewSummary();
+        List<ItemDto> newReleases = itemService.getNewItemsWithReviewSummary();
 
-        newReleases.forEach(item -> {
-            ItemDto summary = itemService.getItemWithReviewSummary(item.getItemId());
-            if (summary != null) {
-                item.setAverageRating(summary.getAverageRating());
-                item.setReviewCount(summary.getReviewCount());
-            }
-        });
+//        bestSellers.forEach(item -> {
+//            ItemDto summary = itemService.getItemWithReviewSummary(item.getItemId());
+//            if (summary != null) {
+//                item.setAverageRating(summary.getAverageRating());
+//                item.setReviewCount(summary.getReviewCount());
+//            }
+//        });
+
+//        newReleases.forEach(item -> {
+//            ItemDto summary = itemService.getItemWithReviewSummary(item.getItemId());
+//            if (summary != null) {
+//                item.setAverageRating(summary.getAverageRating());
+//                item.setReviewCount(summary.getReviewCount());
+//            }
+//        });
 
         model.addAttribute("bestSellers", bestSellers);
         model.addAttribute("newReleases", newReleases);
@@ -119,45 +124,3 @@ public class HomeController {
         return "home";
     }
 }
-
-
-
-//        // 추가: 로그인/로그아웃 메시지 처리
-//        if (message != null && !message.trim().isEmpty()) {
-//            model.addAttribute("message", message);
-//        }
-
-//        //  디버깅: 세션 정보 확인
-//        System.out.println("=== HomeController 디버깅 ===");
-//        System.out.println("session.getAttribute('userId'): " + session.getAttribute("userId"));
-//        System.out.println("session.getAttribute('email'): " + session.getAttribute("email"));
-//        System.out.println("session.getAttribute('user'): " + session.getAttribute("user"));
-//
-//        //  모델에 세션 정보 강제로 추가
-//        Long userId = (Long) session.getAttribute("userId");
-//        Object user = session.getAttribute("user");
-//
-//        if (userId != null || user != null) {
-//            model.addAttribute("sessionUserId", userId);
-//            model.addAttribute("sessionUser", user);
-//            model.addAttribute("isLoggedIn", true);
-//            System.out.println("✅ 로그인 상태로 모델에 추가됨");
-//        } else {
-//            model.addAttribute("isLoggedIn", false);
-//            System.out.println("❌ 로그인 상태 아님");
-//        }
-
-
-//        // 세션 정보를 모델에 추가 (header.html에서 사용하기 위해)
-//        Long userId = (Long) session.getAttribute("userId");
-//        String email = (String) session.getAttribute("email");
-//
-//        if (userId != null) {
-//            model.addAttribute("isLoggedIn", true);
-//            model.addAttribute("userEmail", email);
-//            // session.user 방식과 호환되도록 추가
-//            model.addAttribute("userId", userId);
-//        } else {
-//            model.addAttribute("isLoggedIn", false);
-//        }
-

--- a/src/main/java/com/example/shoppingmall/admin/dao/AdminLoginStatusDao.java
+++ b/src/main/java/com/example/shoppingmall/admin/dao/AdminLoginStatusDao.java
@@ -2,11 +2,9 @@ package com.example.shoppingmall.admin.dao;
 
 import com.example.shoppingmall.admin.dto.LoginHistoryDto;
 import com.example.shoppingmall.admin.dto.LoginStatusSearchDto;
-import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
 
-@Mapper  // 어노테이션은 유지하지만 실제로는 Impl이 동작
 public interface AdminLoginStatusDao {
     List<LoginHistoryDto> selectLoginHistories(LoginStatusSearchDto searchDto);
     int countLoginHistories(LoginStatusSearchDto searchDto);

--- a/src/main/java/com/example/shoppingmall/cart/dao/CartDao.java
+++ b/src/main/java/com/example/shoppingmall/cart/dao/CartDao.java
@@ -1,39 +1,45 @@
 package com.example.shoppingmall.cart.dao;
 
 import com.example.shoppingmall.cart.domain.CartDto;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-
 
 import java.util.List;
 
-
-@Mapper
 public interface CartDao {
-
 
     //해당 유저의 장바구니 목록 반환
     List<CartDto> selectCartByUserId(@Param("userId")Long userId) throws Exception;
+
     //해당 유저의 장바구니에 해당 물품이 있는지 확인
     //CartDto selectByUserIdAndItemId(@Param("userId")int userId, @Param("itemId")int itemId) throws Exception;
+
     //장바구니에 상품 추가
     int insert(CartDto cart) throws Exception;
+
     //기존 상품의 수량&금액 수정
     int updateItemQuantity(CartDto cart) throws Exception;
+
     //단일 항목 삭제
     int deleteByCartId(Long cartId) throws Exception;
+
     //여러 항목 일괄 삭제
     void deleteByCartIds(List<Long> cartIds) throws Exception;
+
     //전체 삭제 (유저 기준)
     int deleteAllByUserId(Long userId) throws Exception;
+
     //해당 유저의 장바구니 상품 수 집계
     int countByUserId(Long userId) throws Exception;
+
     // ✅ 새로 추가한 메서드 (수량만 바꾸는)
     void updateQuantity(@Param("cartId") Long cartId, @Param("quantity") int quantity) throws Exception;
+
     //관심상품에 추가
     void addToWishlist(@Param("userId") Long userId, @Param("itemId") Long itemId) throws Exception;
+
     //장바구니 추가
     void insertCart(CartDto cartDto);
+
     CartDto selectExistingCartItem(CartDto cartDto);
 
     List<CartDto> selectCartsByIds(@Param("list") List<Long> cartIds);

--- a/src/main/java/com/example/shoppingmall/cart/dao/impl/CartDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/cart/dao/impl/CartDaoImpl.java
@@ -1,0 +1,92 @@
+package com.example.shoppingmall.cart.dao.impl;
+
+import com.example.shoppingmall.cart.dao.CartDao;
+import com.example.shoppingmall.cart.domain.CartDto;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class CartDaoImpl implements CartDao {
+
+    private final SqlSession sqlSession;
+
+    private static final String NAMESPACE = "com.example.shoppingmall.cart.dao.CartDao.";
+
+    public CartDaoImpl(SqlSession sqlSession) {
+        this.sqlSession = sqlSession;
+    }
+
+    @Override
+    public List<CartDto> selectCartByUserId(Long userId) {
+        return sqlSession.selectList(NAMESPACE + "selectCartByUserId", userId);
+    }
+
+    @Override
+    public int insert(CartDto cart) {
+        return sqlSession.insert(NAMESPACE + "insert", cart);
+    }
+
+    @Override
+    public int updateItemQuantity(CartDto cart) {
+        return sqlSession.update(NAMESPACE + "updateItemQuantity", cart);
+    }
+
+    @Override
+    public int deleteByCartId(Long cartId) {
+        return sqlSession.delete(NAMESPACE + "deleteByCartId", cartId);
+    }
+
+    @Override
+    public void deleteByCartIds(List<Long> cartIds) {
+        // XML의 <foreach collection="list">와 매핑됨
+        sqlSession.delete(NAMESPACE + "deleteByCartIds", cartIds);
+    }
+
+    @Override
+    public int deleteAllByUserId(Long userId) {
+        return sqlSession.delete(NAMESPACE + "deleteAllByUserId", userId);
+    }
+
+    @Override
+    public int countByUserId(Long userId) {
+        return sqlSession.selectOne(NAMESPACE + "countByUserId", userId);
+    }
+
+    @Override
+    public void updateQuantity(Long cartId, int quantity) {
+        // 파라미터가 2개 이상이므로 Map으로 전달
+        Map<String, Object> params = new HashMap<>();
+        params.put("cartId", cartId);
+        params.put("quantity", quantity);
+        sqlSession.update(NAMESPACE + "updateQuantity", params);
+    }
+
+    @Override
+    public void addToWishlist(Long userId, Long itemId) {
+        // XML의 parameterType="map"에 맞춰 Map으로 전달
+        Map<String, Object> params = new HashMap<>();
+        params.put("userId", userId);
+        params.put("itemId", itemId);
+        sqlSession.insert(NAMESPACE + "addToWishlist", params);
+    }
+
+    @Override
+    public void insertCart(CartDto cartDto) {
+        sqlSession.insert(NAMESPACE + "insertCart", cartDto);
+    }
+
+    @Override
+    public CartDto selectExistingCartItem(CartDto cartDto) {
+        return sqlSession.selectOne(NAMESPACE + "selectExistingCartItem", cartDto);
+    }
+
+    @Override
+    public List<CartDto> selectCartsByIds(List<Long> cartIds) {
+        // XML의 <foreach collection="list">와 매핑됨
+        return sqlSession.selectList(NAMESPACE + "selectCartsByIds", cartIds);
+    }
+}

--- a/src/main/java/com/example/shoppingmall/item/dao/ItemDao.java
+++ b/src/main/java/com/example/shoppingmall/item/dao/ItemDao.java
@@ -30,4 +30,7 @@ public interface ItemDao {
 
     ItemDto selectItemWithReviewSummary(Long itemId);
 
+    List<ItemDto> findBestSellersWithReviewSummary();
+
+    List<ItemDto> findNewItemsWithReviewSummary();
 }

--- a/src/main/java/com/example/shoppingmall/item/dao/ItemDao.java
+++ b/src/main/java/com/example/shoppingmall/item/dao/ItemDao.java
@@ -27,6 +27,7 @@ public interface ItemDao {
     List<Item> findItemsByCategory(@Param("majorId") Long majorId,
                                    @Param("middleId") Long middleId,
                                    @Param("minorId") Long minorId);
+
     ItemDto selectItemWithReviewSummary(Long itemId);
 
 }

--- a/src/main/java/com/example/shoppingmall/item/dao/impl/CategoryDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/item/dao/impl/CategoryDaoImpl.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class CategoryDaoImpl implements CategoryDao {
 
     private final SqlSession sqlSession;
-    private static final String NAMESPACE = "CategoryMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.item.dao.CategoryDao.";
 
     public CategoryDaoImpl(SqlSession sqlSession) {
         this.sqlSession = sqlSession;

--- a/src/main/java/com/example/shoppingmall/item/dao/impl/ItemDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/item/dao/impl/ItemDaoImpl.java
@@ -3,7 +3,6 @@ package com.example.shoppingmall.item.dao.impl;
 import com.example.shoppingmall.item.dao.ItemDao;
 import com.example.shoppingmall.item.domain.Item;
 import com.example.shoppingmall.item.domain.dto.ItemDto;
-import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.stereotype.Repository;
 
@@ -15,7 +14,7 @@ import java.util.Map;
 public class ItemDaoImpl implements ItemDao {
 
     private final SqlSession sqlSession;
-    private static final String NAMESPACE = "ItemMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.item.dao.ItemDao.";
 
     public ItemDaoImpl(SqlSession sqlSession) {
         this.sqlSession = sqlSession;

--- a/src/main/java/com/example/shoppingmall/item/dao/impl/ItemDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/item/dao/impl/ItemDaoImpl.java
@@ -73,4 +73,14 @@ public class ItemDaoImpl implements ItemDao {
     public ItemDto selectItemWithReviewSummary(Long itemId) {
         return sqlSession.selectOne(NAMESPACE + "selectItemWithReviewSummary", itemId);
     }
+
+    @Override
+    public List<ItemDto> findBestSellersWithReviewSummary() {
+        return sqlSession.selectList(NAMESPACE + "findBestSellersWithReviewSummary");
+    }
+
+    @Override
+    public List<ItemDto> findNewItemsWithReviewSummary() {
+        return sqlSession.selectList(NAMESPACE + "findNewItemsWithReviewSummary");
+    }
 }

--- a/src/main/java/com/example/shoppingmall/item/dao/impl/ItemOptionDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/item/dao/impl/ItemOptionDaoImpl.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class ItemOptionDaoImpl implements ItemOptionDao {
 
     private final SqlSessionTemplate sqlSession;
-    private static final String NAMESPACE = "ItemOptionMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.item.dao.ItemOptionDao.";
 
     public ItemOptionDaoImpl(SqlSessionTemplate sqlSession) {
         this.sqlSession = sqlSession;

--- a/src/main/java/com/example/shoppingmall/item/service/impl/ItemServiceImpl.java
+++ b/src/main/java/com/example/shoppingmall/item/service/impl/ItemServiceImpl.java
@@ -124,32 +124,12 @@ public class ItemServiceImpl implements ItemService {
 
     @Override
     public List<ItemDto> getBestSellersWithReviewSummary() {
-        List<ItemDto> items = getBestSellers(); // 기존 메서드 사용
-
-        for (ItemDto item : items) {
-            ItemDto reviewSummary = itemDao.selectItemWithReviewSummary(item.getItemId());
-            if (reviewSummary != null) {
-                item.setAverageRating(reviewSummary.getAverageRating());
-                item.setReviewCount(reviewSummary.getReviewCount());
-            }
-        }
-
-        return items;
+        return itemDao.findBestSellersWithReviewSummary();
     }
 
     @Override
     public List<ItemDto> getNewItemsWithReviewSummary() {
-        List<ItemDto> items = getNewItems();
-
-        for (ItemDto item : items) {
-            ItemDto reviewSummary = itemDao.selectItemWithReviewSummary(item.getItemId());
-            if (reviewSummary != null) {
-                item.setAverageRating(reviewSummary.getAverageRating());
-                item.setReviewCount(reviewSummary.getReviewCount());
-            }
-        }
-
-        return items;
+        return itemDao.findNewItemsWithReviewSummary();
     }
 
 

--- a/src/main/java/com/example/shoppingmall/itemquestion/dao/impl/ItemQuestionDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/itemquestion/dao/impl/ItemQuestionDaoImpl.java
@@ -1,6 +1,7 @@
-package com.example.shoppingmall.itemquestion.dao;
+package com.example.shoppingmall.itemquestion.dao.impl;
 
 
+import com.example.shoppingmall.itemquestion.dao.ItemQuestionDao;
 import com.example.shoppingmall.itemquestion.domain.ItemQuestion;
 import com.example.shoppingmall.common.dto.PageRequestDto;
 import org.apache.ibatis.session.SqlSession;
@@ -12,7 +13,7 @@ import java.util.List;
 @Repository
 public class ItemQuestionDaoImpl implements ItemQuestionDao {
     private final SqlSession sqlSession;
-    private static final String namespace = "ItemQuestionMapper";
+    private static final String NAMESPACE = "com.example.shoppingmall.itemquestion.dao.ItemQuestionDao.";
 
     public ItemQuestionDaoImpl(SqlSession sqlSession) {
         this.sqlSession = sqlSession;
@@ -21,31 +22,31 @@ public class ItemQuestionDaoImpl implements ItemQuestionDao {
     //전체조회
     @Override
     public List<ItemQuestion> findAll() {
-        return sqlSession.selectList(namespace + "findAll");
+        return sqlSession.selectList(NAMESPACE + "findAll");
     }
 
     //단건조회
     @Override
     public ItemQuestion findById(Long id) {
-        return sqlSession.selectOne(namespace + "findById", id);
+        return sqlSession.selectOne(NAMESPACE + "findById", id);
     }
 
     //등록
     @Override
     public void insert(ItemQuestion itemQuestion) {
-        sqlSession.insert(namespace + "insert", itemQuestion);
+        sqlSession.insert(NAMESPACE + "insert", itemQuestion);
     }
 
     //수정
     @Override
     public int update(ItemQuestion itemQuestion) {
-        return sqlSession.update(namespace + "update", itemQuestion);
+        return sqlSession.update(NAMESPACE + "update", itemQuestion);
     }
 
     //삭제
     @Override
     public void delete(Long id) {
-        sqlSession.update(namespace + "delete", id);
+        sqlSession.update(NAMESPACE + "delete", id);
     }
 
     @Override
@@ -53,12 +54,12 @@ public class ItemQuestionDaoImpl implements ItemQuestionDao {
         var params = new java.util.HashMap<String, Object>();
         params.put("offset", pageRequestDto.getOffset());
         params.put("limit", pageRequestDto.getLimit());
-        return sqlSession.selectList(namespace + "findPage", params);
+        return sqlSession.selectList(NAMESPACE + "findPage", params);
     }
 
     @Override
     public int count() {
-        return sqlSession.selectOne(namespace + "count");
+        return sqlSession.selectOne(NAMESPACE + "count");
     }
 
     @Override
@@ -67,11 +68,11 @@ public class ItemQuestionDaoImpl implements ItemQuestionDao {
         params.put("keyword", keyword);
         params.put("limit", limit);
         params.put("offset", offset);
-        return sqlSession.selectList(namespace + "findByKeyword", params);
+        return sqlSession.selectList(NAMESPACE + "findByKeyword", params);
     }
 
     @Override
     public int countByKeyword(String keyword) {
-        return sqlSession.selectOne(namespace + "countByKeyword", keyword);
+        return sqlSession.selectOne(NAMESPACE + "countByKeyword", keyword);
     }
 }

--- a/src/main/java/com/example/shoppingmall/notice/dao/impl/NoticeDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/notice/dao/impl/NoticeDaoImpl.java
@@ -1,5 +1,6 @@
-package com.example.shoppingmall.notice.dao;
+package com.example.shoppingmall.notice.dao.impl;
 
+import com.example.shoppingmall.notice.dao.NoticeDao;
 import com.example.shoppingmall.notice.domain.Notice;
 import com.example.shoppingmall.common.dto.PageRequestDto;
 import org.apache.ibatis.session.SqlSession;
@@ -10,38 +11,41 @@ import java.util.List;
 @Repository
 public class NoticeDaoImpl implements NoticeDao {
     private final SqlSession sqlSession;
-    private static final String namespace = "NoticeMapper.";
+
+    private static final String NAMESPACE = "com.example.shoppingmall.notice.dao.NoticeDao.";
 
     public NoticeDaoImpl(SqlSession sqlSession) {
         this.sqlSession = sqlSession;
     }
-        @Override
-        public List<Notice> findAll(){
-            return sqlSession.selectList("NoticeMapper.findAll");
+
+    @Override
+    public List<Notice> findAll(){
+        return sqlSession.selectList(NAMESPACE + "findAll");
     }
-        @Override
-        public Notice findById(Long id){
-            return sqlSession.selectOne("NoticeMapper.findById",id);
+
+    @Override
+    public Notice findById(Long id){
+        return sqlSession.selectOne(NAMESPACE + "findById", id);
     }
 
     @Override
     public void insert(Notice notice){
-            sqlSession.insert("NoticeMapper.insert",notice);
+        sqlSession.insert(NAMESPACE + "insert", notice);
     }
 
     @Override
     public int update(Notice notice){
-        return sqlSession.update("NoticeMapper.update",notice);
-
+        return sqlSession.update(NAMESPACE + "update", notice);
     }
 
     @Override
     public void delete(Long id){
-            sqlSession.delete("NoticeMapper.delete",id);
+        sqlSession.delete(NAMESPACE + "delete", id);
     }
+
     @Override
     public int increaseViewCount(Long noticeId){
-        return sqlSession.update("NoticeMapper.increaseViewCount",noticeId);
+        return sqlSession.update(NAMESPACE + "increaseViewCount", noticeId);
     }
 
     @Override
@@ -49,11 +53,12 @@ public class NoticeDaoImpl implements NoticeDao {
         var params = new java.util.HashMap<String, Object>();
         params.put("offset", pageRequestDto.getOffset());
         params.put("limit", pageRequestDto.getLimit());
-        return sqlSession.selectList("NoticeMapper.findPage");
+
+        return sqlSession.selectList(NAMESPACE + "findPage", params);
     }
 
     @Override
     public int count(){
-        return sqlSession.selectOne(namespace + "count");
+        return sqlSession.selectOne(NAMESPACE + "count");
     }
 }

--- a/src/main/java/com/example/shoppingmall/order/dao/impl/OrderDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/order/dao/impl/OrderDaoImpl.java
@@ -1,5 +1,6 @@
-package com.example.shoppingmall.order.dao;
+package com.example.shoppingmall.order.dao.impl;
 
+import com.example.shoppingmall.order.dao.OrderDao;
 import com.example.shoppingmall.order.domain.OrderDto;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,7 @@ public class OrderDaoImpl implements OrderDao {
 
     @Autowired
     private SqlSession sqlSession;
-    private static final String NAMESPACE = "OrderMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.order.dao.OrderDao.";
 
     @Override
     public int insertOrder(OrderDto orderDto) {

--- a/src/main/java/com/example/shoppingmall/order/dao/impl/OrderItemDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/order/dao/impl/OrderItemDaoImpl.java
@@ -1,5 +1,6 @@
-package com.example.shoppingmall.order.dao;
+package com.example.shoppingmall.order.dao.impl;
 
+import com.example.shoppingmall.order.dao.OrderItemDao;
 import com.example.shoppingmall.order.domain.OrderItemDto;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,7 @@ public class OrderItemDaoImpl implements OrderItemDao {
 
     @Autowired
     private SqlSession sqlSession;
-    private static final String NAMESPACE = "OrderItemMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.order.dao.OrderItemDao.";
 
     @Override
     public int insertOrderItem(OrderItemDto orderItemDto) {

--- a/src/main/java/com/example/shoppingmall/review/dao/ReviewDao.java
+++ b/src/main/java/com/example/shoppingmall/review/dao/ReviewDao.java
@@ -1,16 +1,9 @@
 package com.example.shoppingmall.review.dao;
 
-
-import com.example.shoppingmall.cart.domain.CartDto;
 import com.example.shoppingmall.review.domain.ReviewDto;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
-
 
 import java.util.List;
 
-
-@Mapper
 public interface ReviewDao {
     ReviewDto findById(Long reviewId);
     void incrementView(Long reviewId);

--- a/src/main/java/com/example/shoppingmall/review/dao/impl/ReviewDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/review/dao/impl/ReviewDaoImpl.java
@@ -1,0 +1,46 @@
+package com.example.shoppingmall.review.dao.impl;
+
+import com.example.shoppingmall.review.dao.ReviewDao;
+import com.example.shoppingmall.review.domain.ReviewDto;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class ReviewDaoImpl implements ReviewDao {
+
+    private final SqlSession sqlSession;
+
+    private static final String NAMESPACE = "com.example.shoppingmall.review.dao.ReviewDao.";
+
+    // 생성자 주입
+    public ReviewDaoImpl(SqlSession sqlSession) {
+        this.sqlSession = sqlSession;
+    }
+
+    @Override
+    public ReviewDto findById(Long reviewId) {
+        return sqlSession.selectOne(NAMESPACE + "findById", reviewId);
+    }
+
+    @Override
+    public void incrementView(Long reviewId) {
+        sqlSession.update(NAMESPACE + "incrementView", reviewId);
+    }
+
+    @Override
+    public List<ReviewDto> selectAllReviews() {
+        return sqlSession.selectList(NAMESPACE + "selectAllReviews");
+    }
+
+    @Override
+    public List<ReviewDto> selectReviewsByItemId(Long itemId) {
+        return sqlSession.selectList(NAMESPACE + "selectReviewsByItemId", itemId);
+    }
+
+    @Override
+    public List<ReviewDto> findReviewsByItemId(int itemId) {
+        return sqlSession.selectList(NAMESPACE + "findReviewsByItemId", itemId);
+    }
+}

--- a/src/main/java/com/example/shoppingmall/user/dao/UserDao.java
+++ b/src/main/java/com/example/shoppingmall/user/dao/UserDao.java
@@ -1,10 +1,7 @@
 package com.example.shoppingmall.user.dao;
 
 import com.example.shoppingmall.user.domain.User;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-
-// Mapper 어노테이션 제거 (XML 방식 사용)
 
 public interface UserDao {
 

--- a/src/main/java/com/example/shoppingmall/user/dao/WishlistDao.java
+++ b/src/main/java/com/example/shoppingmall/user/dao/WishlistDao.java
@@ -2,12 +2,10 @@ package com.example.shoppingmall.user.dao;
 
 import com.example.shoppingmall.user.domain.dto.WishlistDto;
 import com.example.shoppingmall.user.domain.dto.WishlistSearchDto;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
-@Mapper
 public interface WishlistDao {
     List<WishlistDto> selectWishlist(WishlistSearchDto searchDto);
     int countWishlist(Long userId);

--- a/src/main/java/com/example/shoppingmall/user/dao/impl/DeliveryAddressDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/user/dao/impl/DeliveryAddressDaoImpl.java
@@ -1,5 +1,6 @@
-package com.example.shoppingmall.user.dao;
+package com.example.shoppingmall.user.dao.impl;
 
+import com.example.shoppingmall.user.dao.DeliveryAddressDao;
 import com.example.shoppingmall.user.domain.DeliveryAddressDto;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.session.SqlSession;
@@ -13,7 +14,7 @@ public class DeliveryAddressDaoImpl implements DeliveryAddressDao {
 
     @Autowired
     private SqlSession sqlSession;
-    private static final String NAMESPACE = "DeliveryAddressMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.user.dao.DeliveryAddressDao.";
 
     @Override
     public List<DeliveryAddressDto> selectActiveAddressesByUserId(Long userId) {

--- a/src/main/java/com/example/shoppingmall/user/dao/impl/UserDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/user/dao/impl/UserDaoImpl.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class UserDaoImpl implements UserDao {
 
     private final SqlSession sqlSession;
-    private static final String NAMESPACE = "UserMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.user.dao.UserDao.";
 
     public UserDaoImpl(SqlSession sqlSession) {
         this.sqlSession = sqlSession;

--- a/src/main/java/com/example/shoppingmall/user/dao/impl/WishlistDaoImpl.java
+++ b/src/main/java/com/example/shoppingmall/user/dao/impl/WishlistDaoImpl.java
@@ -12,9 +12,8 @@ import java.util.Map;
 
 @Repository
 public class WishlistDaoImpl implements WishlistDao {
-    // ... 나머지 코드는 동일
     private final SqlSession sqlSession;
-    private static final String NAMESPACE = "WishlistMapper.";
+    private static final String NAMESPACE = "com.example.shoppingmall.user.dao.WishlistDao.";
 
     public WishlistDaoImpl(SqlSession sqlSession) {
         this.sqlSession = sqlSession;

--- a/src/main/resources/mapper/ItemMapper.xml
+++ b/src/main/resources/mapper/ItemMapper.xml
@@ -81,4 +81,47 @@
         WHERE i.item_id = #{itemId}
         GROUP BY i.item_id, i.name
     </select>
+
+    <select id="findBestSellersWithReviewSummary" resultType="com.example.shoppingmall.item.domain.dto.ItemDto">
+        SELECT
+            i.item_id AS itemId,
+            i.category_id AS categoryId,
+            i.name, i.image, i.description, i.price, i.status, i.grade,
+            i.manufacture_country AS manufactureCountry,
+            i.is_best_seller AS isBestSeller,
+            i.is_new AS isNew,
+            ROUND(AVG(r.rating), 1) AS averageRating,
+            COUNT(r.review_id) AS reviewCount
+        FROM
+            item i
+                LEFT JOIN
+            review r ON i.item_id = r.item_id
+        WHERE
+            i.is_best_seller = true
+        GROUP BY
+            i.item_id, i.category_id, i.name, i.image, i.description, i.price,
+            i.status, i.grade, i.manufacture_country, i.is_best_seller, i.is_new
+    </select>
+
+    <select id="findNewItemsWithReviewSummary" resultType="com.example.shoppingmall.item.domain.dto.ItemDto">
+        SELECT
+            i.item_id AS itemId,
+            i.category_id AS categoryId,
+            i.name, i.image, i.description, i.price, i.status, i.grade,
+            i.manufacture_country AS manufactureCountry,
+            i.is_best_seller AS isBestSeller,
+            i.is_new AS isNew,
+            ROUND(AVG(r.rating), 1) AS averageRating,
+            COUNT(r.review_id) AS reviewCount
+        FROM
+            item i
+                LEFT JOIN
+            review r ON i.item_id = r.item_id
+        WHERE
+            i.is_new = true
+        GROUP BY
+            i.item_id, i.category_id, i.name, i.image, i.description, i.price,
+            i.status, i.grade, i.manufacture_country, i.is_best_seller, i.is_new
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -2,12 +2,28 @@
 <!DOCTYPE configuration
         PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
 <configuration>
 
+    <!-- ============================= -->
+    <!-- MyBatis 전역 설정 -->
+    <!-- ============================= -->
+    <!-- mapUnderscoreToCamelCase:
+         DB 컬럼명이 snake_case(item_id)일 때
+         자바 필드명 camelCase(itemId)로 자동 매핑 -->
     <settings>
         <setting name="mapUnderscoreToCamelCase" value="true"/>
     </settings>
 
+    <!-- ============================= -->
+    <!-- Type Alias 설정 -->
+    <!-- ============================= -->
+    <!-- 지정한 패키지 내 클래스들을 별칭(alias)으로 등록 -->
+    <!-- 매퍼 XML에서 resultType, parameterType 지정 시
+         클래스의 전체 경로(FQCN)를 쓰지 않고
+         간단한 별칭(alias)으로 사용하기 위해 설정 -->
+    <!-- 예: com.example.shoppingmall.user.domain.User → User -->
+    <!-- 따라서 매퍼 XML에서는 resultType="User" 형태로 간단히 작성 가능 -->
     <typeAliases>
         <package name="com.example.shoppingmall.user.domain"/>
         <package name="com.example.shoppingmall.review.domain"/>
@@ -19,8 +35,17 @@
         <package name="com.example.shoppingmall.admin.domain"/>
     </typeAliases>
 
+    <!-- ============================= -->
+    <!-- Mapper 설정 (주석 처리) -->
+    <!-- ============================= -->
+    <!-- 원래는 <mappers> 태그를 통해 매퍼 XML 위치를 지정할 수 있음 -->
+    <!-- 하지만 root-context.xml에서 SqlSessionFactoryBean의
+         mapperLocations 속성을 통해 이미 매퍼 XML 경로를 지정했으므로 중복됨 -->
+    <!-- 따라서 아래 설정은 불필요하여 주석 처리 -->
+    <!--
     <mappers>
         <package name="com.example.shoppingmall"/>
     </mappers>
+    -->
 
 </configuration>

--- a/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -44,7 +44,9 @@
     </beans:bean>
 
     <!-- Component Scan -->
-    <context:component-scan base-package="com.example.shoppingmall, com.example.shoppingmall.admin.controller, com.example.shoppingmall.cart.controller, com.example.shoppingmall.item.controller, com.example.shoppingmall.itemquestion.controller, com.example.shoppingmall.notice.controller, com.example.shoppingmall.order.controller, com.example.shoppingmall.review.controller, com.example.shoppingmall.user.controller"/>
-
+    <!-- servlet-context.xml은 웹 계층(@Controller, ViewResolver, HandlerMapping)에 대한 설정(Bean 등록) 담당-->
+    <context:component-scan base-package="com.example.shoppingmall" use-default-filters="false">
+        <context:include-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
+    </context:component-scan>
 
 </beans:beans>

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -6,10 +6,14 @@
            http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
+    <!-- ============================= -->
     <!-- 외부 properties 파일 로딩 -->
+    <!-- ============================= -->
     <context:property-placeholder location="classpath:db.properties, classpath:mail.properties"/>
 
+    <!-- ============================= -->
     <!-- DB 연결 설정 -->
+    <!-- ============================= -->
     <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
         <property name="driverClassName" value="${db.driver}"/>
         <property name="url" value="${db.url}"/>
@@ -17,40 +21,71 @@
         <property name="password" value="${db.password}"/>
     </bean>
 
+    <!-- ============================= -->
     <!-- MyBatis SqlSessionFactory 설정 -->
-    <!-- (추후에 property에 따라서 domain 세부 경로 설정 필요, 루트 경로로 하면 성능 저하 발생)-->
+    <!-- ============================= -->
+    <!-- SqlSessionFactoryBean을 통해 MyBatis와 Spring 연동 -->
+    <!-- configLocation: mybatis-config.xml (전역 설정) -->
+    <!-- mapperLocations: 매퍼 XML 파일 경로 지정 -->
     <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource"/>
         <property name="configLocation" value="classpath:mybatis-config.xml"/>
         <property name="mapperLocations" value="classpath:/mapper/**/*.xml"/>
     </bean>
 
-    <!-- MyBatis SqlSessionTemplate (선택) -->
+    <!-- ============================= -->
+    <!-- MyBatis SqlSessionTemplate 설정 -->
+    <!-- ============================= -->
+    <!-- SqlSession을 스프링 환경에 맞게 감싼 템플릿 객체 -->
+    <!-- 스레드 세이프, 트랜잭션 연동, 예외 변환 제공 -->
+    <!-- 매퍼 인터페이스만 쓰면 생략 가능하지만, 현재는 SqlSession 직접 호출 DAO가 있어 반드시 필요 -->
     <bean id="sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
         <constructor-arg index="0" ref="sqlSessionFactory"/>
     </bean>
 
-    <!-- Mapper 인터페이스 자동 스캔 -->
-    <!-- (추후에 property에 따라서 dao or mapper 세부 경로 설정 필요, 루트 경로로 하면 성능 저하 발생)-->
-    <!-- 루트 경로로 설정했을 때 service를 mapper로 인식하는 오류 발생 -->
-    <!-- Controller가 Mapper로 인식되어서 Binding Exception이 발생함 -> 정확한 Mapper(dao) 설정 필요-->
-    <!-- MapperScannerConfigurer로 직접 등록하는 경우, dao에 @Repository 어노테이션 제거하기 (중복 등록 됨) -->
+    <!-- ============================= -->
+    <!-- Mapper 등록 (컴포넌트 스캔 방식) -->
+    <!-- ============================= -->
+    <!-- @Repository 어노테이션이 붙은 Mapper 인터페이스(DAO) 자동 스캔 -->
+    <!-- Controller는 제외하여 Binding Exception 방지(웹 계층(@Controller)에 대한 설정은 servlet-context.xml에서 담당) -->
+    <!-- MapperScannerConfigurer로 등록하는 경우, dao에 @Repository 어노테이션 제거하기 (중복 등록 됨) -->
     <context:component-scan base-package="com.example.shoppingmall">
         <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
     </context:component-scan>
 
-    <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-        <!-- <property name="basePackage" value="com.example.shoppingmall"/> -->
-        <property name="basePackage"
-                  value="com.example.shoppingmall.user.dao, com.example.shoppingmall.review.dao, com.example.shoppingmall.order.dao, com.example.shoppingmall.notice.dao, com.example.shoppingmall.itemquestion.dao, com.example.shoppingmall.item.dao, com.example.shoppingmall.cart.dao, com.example.shoppingmall.admin.dao"/>
-    </bean>
 
+    <!-- ============================= -->
+    <!-- Mapper 등록 (대안: MapperScannerConfigurer) -->
+    <!-- ============================= -->
+    <!-- Mapper 인터페이스 패키지를 명시적으로 지정하는 방식 -->
+    <!-- 이 경우 @Repository 어노테이션 제거 필요 (중복 등록 방지) -->
+    <!--
+    <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+        <property name="basePackage"
+                  value="com.example.shoppingmall.user.dao,
+                         com.example.shoppingmall.review.dao,
+                         com.example.shoppingmall.order.dao,
+                         com.example.shoppingmall.notice.dao,
+                         com.example.shoppingmall.itemquestion.dao,
+                         com.example.shoppingmall.item.dao,
+                         com.example.shoppingmall.cart.dao,
+                         com.example.shoppingmall.admin.dao"/>
+    </bean>
+    -->
+
+
+    <!-- ============================= -->
     <!-- 트랜잭션 매니저 설정 -->
+    <!-- ============================= -->
+    <!-- Spring의 선언적 트랜잭션 처리를 위해 DataSourceTransactionManager 등록 -->
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="dataSource"/>
     </bean>
 
-
+    <!-- ============================= -->
+    <!-- 메일 설정 파일 import -->
+    <!-- ============================= -->
+    <!-- 서비스, DAO, 인프라 Bean 등록은 root-context.xml에 등록-->
     <import resource="classpath:mail-config.xml"/>
 
 </beans>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -11,7 +11,7 @@
     <param-value>/WEB-INF/spring/root-context.xml</param-value>
   </context-param>
 
-  <!-- Creates the Spring  Container shared by all Servlets and Filters -->
+  <!-- Creates the Spring Container shared by all Servlets and Filters -->
   <listener>
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
   </listener>


### PR DESCRIPTION
<!-- 
PR 제목 작성 가이드:
형식: <타입>: <간단한 설명>

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- style: 코드 포맷팅
- refactor: 코드 리팩토링
- test: 테스트 추가/수정
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 사용자 로그인 API 구현
-->

## 📝 작업 내용
<!-- 이번 PR에서 구현한 기능이나 수정한 내용을 구체적으로 작성해주세요 -->
### 1. Mapper 등록 방식을 컴포넌트 스캔 방식으 통일
- As-Is: @Mapper (인터페이스)와 @Repository (구현체) 방식 혼용.
- To-Be: @Repository (컴포넌트 스캔) 방식으로 통일.
  - 모든 DAO 인터페이스에서 @Mapper, @Param 어노테이션 제거.
  - root-context.xml에서 MapperScannerConfigurer Bean 제거.

### 2. NAMESPACE 오류 수정
- As-Is: Impl 클래스의 NAMESPACE 상수가 XML 파일명(예: ItemMapper.)으로 잘못 설정됨.
- To-Be: NAMESPACE를 XML의 namespace 속성값(전체 경로, 예: com.example...ItemDao.)과 일치하도록 수정.

### 3. 쿼리 최적화 (N+1 문제 해결 및 동적 SQL)
- N+1 문제 해결:
  - As-Is: 서비스 로직(ItemServiceImpl)에서 목록(N) 조회 후, 반복문 내에서 개별 항목(1)을 추가 조회 (1+N 쿼리).
  - To-Be: JOIN을 사용한 단일 쿼리(예: findBestSellersWithReviewSummary)를 Mapper에 추가, 서비스가 이를 직접 호출하도록 변경 (1+N 쿼리 → 단일 쿼리).
- 동적 쿼리 활용:
  - <if> 태그 등을 사용한 동적 쿼리(예: findItemsByCategory)를 활용하여, 다양한 검색 조건에 따라 최적화된 SQL이 동적으로 실행되도록 함.


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #이슈번호
- Related to #이슈번호

## 💬 추가 요청사항
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 질문이 있다면 작성해주세요 --> 

## ✅ 체크리스트
### 코드 품질
- [X] 커밋 컨벤션 준수 (feat/fix/docs/refactor 등)
- [X] 불필요한 코드/주석 제거

### 테스트
- [X] 로컬 환경에서 동작 확인 완료
- [X] 기존 기능에 영향 없음 확인

### 리뷰
- [ ] 적절한 리뷰어 지정 완료
- [ ] 리뷰어 1명 이상 승인

### 배포 준비
- [ ] 환경변수 추가/변경사항 문서화
- [ ] DB 마이그레이션 필요 여부 확인
- [ ] 배포 시 주의사항 없음
